### PR TITLE
Rename highlight variables

### DIFF
--- a/scripts/tab_desc.R
+++ b/scripts/tab_desc.R
@@ -11,44 +11,44 @@ tab_desc <- function(df, column){
     
     # var numerica ----
     
-    aux <- tab_desc_num(aux, column) %>% 
-      mutate(coloracao = 'J2') %>% ungroup %>%
+    aux <- tab_desc_num(aux, column) %>%
+      mutate(highlight = 'J2') %>% ungroup %>%
       # adiciona linha divisoria para organizacao da tabela
       # destacando o nome da variavel que esta sendo analisada
       add_row(.y. = paste0('[', str_replace_all(stringr::str_to_title(column),
                                                 '_', ' '), ']'),
-              # variavel coloracao servira para adicionar estetica a tabela atraves do 
-              # comando row_spec, por exemplo para destacar por cores se a column se trata
-              # de variaveis numericas, categoricas, etc
-              coloracao = 'J1',
+              # variable highlight serves for styling the table via
+              # kableExtra::row_spec, for instance to mark numeric or
+              # categorical variables with different colors
+              highlight = 'J1',
               ., .before = 1, group1 = msdr(aux$.y.))
   }else{
     
     # var categorica ----
     
     # mostrar quais niveis categoricas existentem para a var cat
-    exemplo_niveis <- paste('Niveis:', paste(sort(unique(aux$.y.)),
+    example_levels <- paste('Niveis:', paste(sort(unique(aux$.y.)),
                                              collapse = ', '))
     # limita o tamanho do vetor para nao desconfigurar a tabela
-    if(str_count(exemplo_niveis)>10){
-      exemplo_niveis <- paste0(str_trim(str_sub(exemplo_niveis,  end = 20)), '...')}
-    
-    se_erro <- class(try(
+    if(str_count(example_levels)>10){
+      example_levels <- paste0(str_trim(str_sub(example_levels,  end = 20)), '...')}
+
+    try_error <- class(try(
       survdiff(data = aux, Surv(aux$tempos, aux$censura)~.y.)[["pvalue"]],
       silent = TRUE))
-    if(se_erro=='try-error'){
+    if(try_error=='try-error'){
       p_value <- 1}else{
         p_value <- survdiff(data = aux,Surv(aux$tempos, aux$censura)~.y.)[["pvalue"]]}
     
     # adiciona linha divisoria para organizacao da tabela
-    aux <- tab_desc_fac(aux) %>% 
-      mutate(coloracao = 'J2') %>% ungroup %>%
+    aux <- tab_desc_fac(aux) %>%
+      mutate(highlight = 'J2') %>% ungroup %>%
       add_row(.y. = paste0('[', str_replace_all(stringr::str_to_title(column),
                                                 '_', ' '), ']'),
-              ., .before = 1, coloracao = 'J1',
-              group1 = exemplo_niveis,
+              ., .before = 1, highlight = 'J1',
+              group1 = example_levels,
               p = as.character(format_sig(p_value)),
               test = '(Logrank)')
   }
-  aux %>% add_row(.after = nrow(aux), coloracao = '.')
+  aux %>% add_row(.after = nrow(aux), highlight = '.')
 }

--- a/skeleton.Rmd
+++ b/skeleton.Rmd
@@ -93,7 +93,7 @@ tabelao %>%
   kbl('html', digits = 4, escape = FALSE, booktabs = TRUE, 
       longtable = TRUE, align = 'c', decimal.mark = ',') %>% 
   kable_classic %>% 
-  row_spec(which(tabelao$coloracao=='J1'), bold = T, color = "black",
+  row_spec(which(tabelao$highlight=='J1'), bold = T, color = "black",
            align = 'c', background = "grey95") %>% 
   column_spec(ncol(tabelao), color = 'white', background = 'white') %>%
   scroll_box(height = "1000px") %>% 


### PR DESCRIPTION
## Summary
- rename `coloracao`, `exemplo_niveis`, and `se_erro` variables to `highlight`, `example_levels`, and `try_error`
- update `skeleton.Rmd` accordingly

Dataset columns `tempos` and `censura` remain unchanged to match example data.

## Testing
- `Rscript` not found; unable to run R-based checks

------
https://chatgpt.com/codex/tasks/task_e_6865320f392c832d917e5e2765c2605d