### PR TITLE
Add documentation and cleanup for summary script

### DIFF
--- a/tests/testthat/test-tab_desc_fac.R
+++ b/tests/testthat/test-tab_desc_fac.R
@@ -1,0 +1,15 @@
+library(SurvInsights)
+
+sample_df <- tibble::tibble(
+  tempos = c(5,10,7,12,20,3),
+  censura = c(1,0,1,1,0,1),
+  group = c('A','B','A','B','A','B')
+)
+aux <- sample_df %>% dplyr::select(tempos, censura, .y.=group)
+
+res <- tab_desc_fac(aux)
+expected <- dplyr::ungroup(dplyr::full_join(tab_freq(aux), msdr_y(aux), by = dplyr::join_by(.y.)))
+
+test_that("tab_desc_fac combines freq and msdr_y", {
+  expect_equal(res, expected)
+})

--- a/tests/testthat/test-tab_desc_num.R
+++ b/tests/testthat/test-tab_desc_num.R
@@ -1,0 +1,22 @@
+library(SurvInsights)
+
+sample_df <- tibble::tibble(
+  tempos = c(5,10,7,12,20,3),
+  censura = c(1,0,1,1,0,1),
+  age = c(70,45,63,50,80,58)
+)
+aux <- sample_df %>% dplyr::select(tempos, censura, .y.=age)
+
+res <- tab_desc_num(aux, 'age')
+fit <- survival::coxph(data = aux, survival::Surv(aux$tempos, aux$censura)~.y.)
+expected <- tibble::tibble(
+  .y. = 'Regression coefficient',
+  group1 = NA,
+  group2 = as.character(round(exp(coef(fit)), 4)),
+  p = format_sig(summary(fit)[["sctest"]][["pvalue"]]),
+  test = 'placeholder'
+)
+
+test_that("tab_desc_num fits cox model", {
+  expect_equal(res, expected)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,12 @@
+library(SurvInsights)
+
+test_that("msdr formats numeric summary correctly", {
+  expect_equal(msdr(c(1,2,3)), "2±1 (1~3)")
+})
+
+test_that("format_sig adds significance stars", {
+  expect_equal(format_sig(0.0007), "0.001***")
+  expect_equal(format_sig(0.02), "0.02**")
+  expect_equal(format_sig(0.06), "0.06*")
+  expect_equal(format_sig(0.2), "0.2")
+})


### PR DESCRIPTION
## Summary
- refactor `scripts/tab_descr_surv.R` with English comments and documentation
- fix variable naming and clarify example usage

## Testing
- `Rscript -e 'library(testthat); test_dir("tests/testthat")'` *(failed: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688519f2b69c832d9b43c4e04f3a0245