### PR TITLE
Replace deprecated mutate_if usage

### DIFF
--- a/R/msdr_y.R
+++ b/R/msdr_y.R
@@ -23,7 +23,7 @@ msdr_y <- function(aux, k = 2){
            sd = fit_sum$se.rmean,
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>% 
-      mutate_if(is.numeric, round, digits = k) %>% 
+      dplyr::mutate(dplyr::across(where(is.numeric), round, digits = k)) %>%
       mutate(group2 = paste0(media, '±', sd,' (',
                              li, '~', ls, ')')) %>% 
       select(.y., group2)
@@ -37,7 +37,7 @@ msdr_y <- function(aux, k = 2){
            sd = fit_sum$se.rmean.,
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>% 
-      mutate_if(is.numeric, round, digits = k) %>% 
+      dplyr::mutate(dplyr::across(where(is.numeric), round, digits = k)) %>%
       mutate(group2 = paste0(media, '±', sd,' (',
                              li, '~', ls, ')')) %>% 
       select(.y., group2)


### PR DESCRIPTION
## Summary
- replace deprecated `mutate_if` with `mutate(across(where(is.numeric), round, digits = k))` in `msdr_y`

## Testing
- `R -q -e "library(testthat); test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_6885505b234c832db4cf3b22a323a25c