### PR TITLE
Replace ± with Unicode escape

### DIFF
--- a/R/msdr_y.R
+++ b/R/msdr_y.R
@@ -24,8 +24,8 @@ msdr_y <- function(aux, k = 2){
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>% 
       mutate_if(is.numeric, round, digits = k) %>% 
-      mutate(group2 = paste0(media, '±', sd,' (',
-                             li, '~', ls, ')')) %>% 
+      mutate(group2 = paste0(media, '\u00B1', sd,' (',
+                             li, '~', ls, ')')) %>%
       select(.y., group2)
   }else{
     fit <- survfit(data = aux,
@@ -38,8 +38,8 @@ msdr_y <- function(aux, k = 2){
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>% 
       mutate_if(is.numeric, round, digits = k) %>% 
-      mutate(group2 = paste0(media, '±', sd,' (',
-                             li, '~', ls, ')')) %>% 
+      mutate(group2 = paste0(media, '\u00B1', sd,' (',
+                             li, '~', ls, ')')) %>%
       select(.y., group2)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,7 +1,7 @@
 msdr <- function(x, k = 2) {
   x <- as.numeric(na.omit(x))
   paste0(
-    round(mean(x), k), "±",
+    round(mean(x), k), "\u00B1",
     round(sd1(x), k), " (",
     paste0(round(min(x), k), '~', round(max(x), k), ")")
   )

--- a/tests/testthat/test-msdr_y.R
+++ b/tests/testthat/test-msdr_y.R
@@ -13,8 +13,8 @@ fit_sum <- data.frame(summary(fit)$table)
 expected <- tibble::tibble(
   .y. = c('A','B'),
   group2 = c(
-    paste0(round(fit_sum$rmean[1],2),'±',round(fit_sum$se.rmean[1],2),' (',round(fit_sum$X0.95LCL[1],2),'~',round(fit_sum$X0.95UCL[1],2),')'),
-    paste0(round(fit_sum$rmean[2],2),'±',round(fit_sum$se.rmean[2],2),' (',round(fit_sum$X0.95LCL[2],2),'~',round(fit_sum$X0.95UCL[2],2),')')
+    paste0(round(fit_sum$rmean[1],2),'\u00B1',round(fit_sum$se.rmean[1],2),' (',round(fit_sum$X0.95LCL[1],2),'~',round(fit_sum$X0.95UCL[1],2),')'),
+    paste0(round(fit_sum$rmean[2],2),'\u00B1',round(fit_sum$se.rmean[2],2),' (',round(fit_sum$X0.95LCL[2],2),'~',round(fit_sum$X0.95UCL[2],2),')')
   )
 )
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,7 +1,7 @@
 library(SurvInsights)
 
 test_that("msdr formats numeric summary correctly", {
-  expect_equal(msdr(c(1,2,3)), "2±1 (1~3)")
+  expect_equal(msdr(c(1,2,3)), "2\u00B11 (1~3)")
 })
 
 test_that("format_sig adds significance stars", {


### PR DESCRIPTION
## Summary
- use `\u00B1` escape instead of raw `±` in R functions
- adjust tests to expect the unicode escape

## Testing
- `R CMD INSTALL .`
- `Rscript -e "library(testthat); test_dir('tests/testthat', reporter='summary')"`

------
https://chatgpt.com/codex/tasks/task_e_68854eb2127c832da10b13e2bc058135