### PR TITLE
Fix placeholder label in tab_desc_num

### DIFF
--- a/R/tab_desc_num.R
+++ b/R/tab_desc_num.R
@@ -1,8 +1,9 @@
 #' @description Unify results for numerical variables
 #' @param aux Data frame with survival data
+#' @param test Label for the statistical test (default "-")
 #' @return A tibble with frequency and survival statistics
 
-tab_desc_num <- function(aux, column, k = 4){
+tab_desc_num <- function(aux, column, k = 4, test = '-'){
   fit <- coxph(data = aux, Surv(aux$tempos, aux$censura)~.y.)
   
   tibble(
@@ -10,5 +11,6 @@ tab_desc_num <- function(aux, column, k = 4){
     group1 = NA,
     group2 = fit %>% coef %>% exp %>% round(., k) %>% as.character, 
     p = format_sig(summary(fit)[["sctest"]][["pvalue"]]),
-    test = 'placeholder'
-  )}
+    test = test
+  )
+}

--- a/scripts/tab_desc_num.R
+++ b/scripts/tab_desc_num.R
@@ -1,14 +1,16 @@
 #' @description Unify results for numerical variables
 #' @param aux Data frame with survival data
+#' @param test Label for the statistical test (default "-")
 #' @return A tibble with frequency and survival statistics
 
-tab_desc_num <- function(aux, column, k = 4){
+tab_desc_num <- function(aux, column, k = 4, test = '-'){
   fit <- coxph(data = aux, Surv(aux$tempos, aux$censura)~.y.)
-  
+
   tibble(
     .y. = 'Regression coefficient',
     group1 = NA,
-    group2 = fit %>% coef %>% exp %>% round(., k) %>% as.character, 
+    group2 = fit %>% coef %>% exp %>% round(., k) %>% as.character,
     p = format_sig(summary(fit)[["sctest"]][["pvalue"]]),
-    test = 'placeholder'
-  )}
+    test = test
+  )
+}

--- a/tests/testthat/test-tab_desc_num.R
+++ b/tests/testthat/test-tab_desc_num.R
@@ -7,14 +7,14 @@ sample_df <- tibble::tibble(
 )
 aux <- sample_df %>% dplyr::select(tempos, censura, .y.=age)
 
-res <- tab_desc_num(aux, 'age')
+res <- tab_desc_num(aux, 'age', test = 'Cox PH')
 fit <- survival::coxph(data = aux, survival::Surv(aux$tempos, aux$censura)~.y.)
 expected <- tibble::tibble(
   .y. = 'Regression coefficient',
   group1 = NA,
   group2 = as.character(round(exp(coef(fit)), 4)),
   p = format_sig(summary(fit)[["sctest"]][["pvalue"]]),
-  test = 'placeholder'
+  test = 'Cox PH'
 )
 
 test_that("tab_desc_num fits cox model", {


### PR DESCRIPTION
## Summary
- allow user to specify survival test label in `tab_desc_num`
- update helper script and unit test

## Testing
- `R CMD INSTALL .`
- `Rscript -e "testthat::test_dir('tests/testthat')"`

------
https://chatgpt.com/codex/tasks/task_e_688550126bac832d97773bc38850fa76