### PR TITLE
Fix README closing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,10 @@ examples.
 
    The rendered HTML will contain the descriptive tables shown in the
    examples.
+
+These tables provide quick summaries of both numeric and categorical
+variables. Survival estimates are reported alongside descriptive
+statistics so you can immediately assess important trends. The helper
+functions `tab_desc_num()`, `tab_desc_fac()`, and `tab_freq()` generate
+the results, which are formatted for publication with `kableExtra`.
+


### PR DESCRIPTION
## Summary
- expand end of README with details about the tables

## Testing
- `R -q -e "library(testthat); testthat::test_local('tests/testthat', reporter='summary')"` *(fails: there is no package called `dplyr`)*

------
https://chatgpt.com/codex/tasks/task_e_68857385d49c832d9e1890b3bedc5dbb