### PR TITLE
Move skeleton example into usage_examples/legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ examples.
 2. Source the helper scripts and render the R Markdown document:
 
    ```r
-   rmarkdown::render("skeleton.Rmd")
+   rmarkdown::render("usage_examples/legacy/skeleton.Rmd")
    ```
 
    The rendered HTML will contain the descriptive tables shown in the

--- a/usage_examples/legacy/skeleton.Rmd
+++ b/usage_examples/legacy/skeleton.Rmd
@@ -28,9 +28,9 @@ library(kableExtra)
 library(tidyverse)
 library(survival)
 
-scripts <- sapply(list.files(path = 'R', recursive = TRUE, pattern = "*.R$"),
+scripts <- sapply(list.files(path = '../../R', recursive = TRUE, pattern = "*.R$"),
        function(x){
-         source(file = paste0('R/', x))
+         source(file = paste0('../../R/', x))
                 invisible()})
 ```
 


### PR DESCRIPTION
## Summary
- Move `skeleton.Rmd` into `usage_examples/legacy/`
- Update skeleton example to source R scripts from its new relative path
- Adjust README to render the relocated skeleton document

## Testing
- `pytest` (no tests found)
- `R -q -e "testthat::test_dir('tests/legacy')"` (no test files found)


------
https://chatgpt.com/codex/tasks/task_e_6895515bc460832d81b9731cfa78ec13