### PR TITLE
refactor summary string formatting

### DIFF
--- a/R/msdr_y.R
+++ b/R/msdr_y.R
@@ -20,8 +20,7 @@ msdr_y <- function(aux, k = 2){
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>%
       dplyr::mutate(dplyr::across(where(is.numeric), \(x) round(x, digits = k))) %>%
-      mutate(group2 = paste0(media, '\u00B1', sd,' (',
-                             li, '~', ls, ')')) %>%
+      mutate(group2 = format_msdr(media, sd, li, ls)) %>%
       select(.y., group2)
   }else{
     fit <- survfit(data = aux,
@@ -34,8 +33,7 @@ msdr_y <- function(aux, k = 2){
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>%
       dplyr::mutate(dplyr::across(where(is.numeric), \(x) round(x, digits = k))) %>%
-      mutate(group2 = paste0(media, '\u00B1', sd,' (',
-                             li, '~', ls, ')')) %>%
+      mutate(group2 = format_msdr(media, sd, li, ls)) %>%
       select(.y., group2)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,3 +1,16 @@
+#' Build a formatted summary string
+#'
+#' @description Internal helper to compose "mean\u00B1sd (li~ls)" strings.
+#' @param mean Mean value.
+#' @param sd Standard deviation.
+#' @param li Lower limit of the range.
+#' @param ls Upper limit of the range.
+#' @return Character string with the formatted summary.
+#' @noRd
+format_msdr <- function(mean, sd, li, ls) {
+  paste0(mean, '\u00B1', sd, ' (', li, '~', ls, ')')
+}
+
 #' Numeric summary string
 #'
 #' @description Format the mean, standard deviation and range of a numeric vector.
@@ -9,10 +22,11 @@
 #' @export
 msdr <- function(x, k = 2) {
   x <- as.numeric(na.omit(x))
-  paste0(
-    round(mean(x), k), "\u00B1",
-    round(sd1(x), k), " (",
-    paste0(round(min(x), k), '~', round(max(x), k), ")")
+  format_msdr(
+    round(mean(x), k),
+    round(sd1(x), k),
+    round(min(x), k),
+    round(max(x), k)
   )
 }
 

--- a/tests/testthat/test-msdr_y.R
+++ b/tests/testthat/test-msdr_y.R
@@ -15,8 +15,18 @@ fit_sum <- data.frame(summary(fit)$table)
 expected <- tibble::tibble(
   .y. = c('A','B'),
   group2 = c(
-    paste0(round(fit_sum$rmean[1],2),'±',round(fit_sum$se.rmean[1],2),' (',round(fit_sum$X0.95LCL[1],2),'~',round(fit_sum$X0.95UCL[1],2),')'),
-    paste0(round(fit_sum$rmean[2],2),'±',round(fit_sum$se.rmean[2],2),' (',round(fit_sum$X0.95LCL[2],2),'~',round(fit_sum$X0.95UCL[2],2),')')
+    SurvInsights:::format_msdr(
+      round(fit_sum$rmean[1], 2),
+      round(fit_sum$se.rmean[1], 2),
+      round(fit_sum$X0.95LCL[1], 2),
+      round(fit_sum$X0.95UCL[1], 2)
+    ),
+    SurvInsights:::format_msdr(
+      round(fit_sum$rmean[2], 2),
+      round(fit_sum$se.rmean[2], 2),
+      round(fit_sum$X0.95LCL[2], 2),
+      round(fit_sum$X0.95UCL[2], 2)
+    )
   )
 )
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -4,6 +4,10 @@ test_that("msdr formats numeric summary correctly", {
   expect_equal(msdr(c(1,2,3)), "2±1 (1~3)")
 })
 
+test_that("format_msdr builds summary string", {
+  expect_equal(SurvInsights:::format_msdr(2,1,1,3), "2±1 (1~3)")
+})
+
 test_that("format_sig adds significance stars", {
   expect_equal(format_sig(0.0007), "0.001***")
   expect_equal(format_sig(0.02), "0.02**")


### PR DESCRIPTION
## Summary
- centralize construction of mean±sd (li~ls) strings via new `format_msdr` utility
- refactor `msdr` and `msdr_y` to use the helper
- add unit tests for `format_msdr` and update expectations accordingly

## Testing
- `R -q -e "testthat::test_dir('tests/testthat')"`


------
https://chatgpt.com/codex/tasks/task_e_6895541ac39c832d97f273040e5c0cb2