### PR TITLE
Add column classifier type labeling test

### DIFF
--- a/tests/testthat/test-column_classifier.R
+++ b/tests/testthat/test-column_classifier.R
@@ -1,0 +1,20 @@
+library(SurvInsights)
+library(dplyr)
+
+test_that("column_classifier identifies basic column types", {
+  df <- data.frame(
+    num = c(1, 2, 3),
+    fac = factor(c("a", "b", "a")),
+    char = c("x", "y", "z")
+  )
+
+  result <- column_classifier(df)
+
+  expected <- data.frame(
+    column = c("char", "fac", "num"),
+    type = c("character", "factor", "numeric"),
+    stringsAsFactors = FALSE
+  )
+
+  expect_equal(result, expected)
+})


### PR DESCRIPTION
## Summary
- add test ensuring `column_classifier` correctly labels numeric, factor, and character columns

## Testing
- `pytest`
- `R -q -e "library(dplyr); testthat::test_dir('tests/testthat')"`
- `R -q -e "testthat::test_dir('tests/legacy')"` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689556d71454832da965e3fb4aa35a3a