### PR TITLE
Add test for complete_tab output

### DIFF
--- a/tests/testthat/test-complete_tab.R
+++ b/tests/testthat/test-complete_tab.R
@@ -1,0 +1,14 @@
+library(SurvInsights)
+
+test_that('complete_tab returns knitr_kable with expected columns', {
+  df <- tibble::tibble(
+    tempos = c(1, 2),
+    censura = c(1, 0),
+    age = c(60, 70)
+  )
+
+  res <- complete_tab(df)
+  expect_s3_class(res, 'knitr_kable')
+  expect_equal(attr(res, 'kable_meta')$col_names,
+               c('.y.', 'group1', 'group2', 'p', 'test', 'highlight'))
+})


### PR DESCRIPTION
## Summary
- add unit test for `complete_tab` verifying knitr_kable output and expected columns

## Testing
- `pytest`
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_6895576f36a0832d98484ac9b1ddc8c3