### PR TITLE
Refactor placeholders to descriptive names

### DIFF
--- a/R/complete_tab.R
+++ b/R/complete_tab.R
@@ -2,14 +2,14 @@
 #' @importFrom kableExtra kbl kable_classic row_spec column_spec scroll_box footnote
 NULL
 
-complete_tab <- function(aux){
-  
-  columns <- column_classifier(aux) %>% 
-    filter(!(column %in% c('tempos', 'censura', '.y.'))) %>% 
+complete_tab <- function(data){
+
+  columns <- column_classifier(data) %>%
+    filter(!(column %in% c('tempos', 'censura', '.y.'))) %>%
     pull(column)
-  
+
   table <- do.call(rbind,
-                   lapply(as.list(columns), FUN = function(x)tab_desc(aux,x)))
+                   lapply(as.list(columns), FUN = function(x)tab_desc(data,x)))
   
   table %>%
     kbl('html', digits = 4, escape = FALSE, booktabs = TRUE,

--- a/R/msdr_y.R
+++ b/R/msdr_y.R
@@ -1,7 +1,7 @@
 #' Mean survival by group
 #'
 #' @description Compute mean survival time and standard error for each group in a dataset.
-#' @param aux Data frame with columns `tempos`, `censura` and grouping variable `.y.`.
+#' @param data Data frame with columns `tempos`, `censura` and grouping variable `.y.`.
 #' @param k Number of decimal places for rounding.
 #' @importFrom tibble tibble
 #' @importFrom dplyr mutate across select
@@ -12,23 +12,23 @@
 #' df <- tibble::tibble(tempos = c(1,2), censura = c(1,0), .y. = c('A','B'))
 #' msdr_y(df)
 #' @export
-msdr_y <- function(aux, k = 2){
+msdr_y <- function(data, k = 2){
 
-  if(length(unique(aux$.y.)) < 2){
-    fit <- survfit(data = aux,
-                   Surv(aux$tempos, aux$censura)~.y.)
+  if(length(unique(data$.y.)) < 2){
+    fit <- survfit(data = data,
+                   Surv(data$tempos, data$censura)~.y.)
     fit_sum <- data.frame(t(summary(fit)$table))
-    tibble(.y. = aux$.y.[1],
+    tibble(.y. = data$.y.[1],
            media = fit_sum$rmean,
            sd = fit_sum$se.rmean,
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>%
       dplyr::mutate(dplyr::across(where(is.numeric), \(x) round(x, digits = k))) %>%
-      mutate(group2 = format_msdr(media, sd, li, ls)) %>%
-      select(.y., group2)
+      mutate(summary_text = format_msdr(media, sd, li, ls)) %>%
+      select(.y., summary_text)
   }else{
-    fit <- survfit(data = aux,
-                   Surv(aux$tempos, aux$censura)~.y.)
+    fit <- survfit(data = data,
+                   Surv(data$tempos, data$censura)~.y.)
     fit_sum <- data.frame(summary(fit)$table)
 
     tibble(.y. = str_remove(rownames(fit_sum), '.y.='),
@@ -37,8 +37,8 @@ msdr_y <- function(aux, k = 2){
            li = fit_sum$X0.95LCL,
            ls = fit_sum$X0.95UCL) %>%
       dplyr::mutate(dplyr::across(where(is.numeric), \(x) round(x, digits = k))) %>%
-      mutate(group2 = format_msdr(media, sd, li, ls)) %>%
-      select(.y., group2)
+      mutate(summary_text = format_msdr(media, sd, li, ls)) %>%
+      select(.y., summary_text)
   }
 }
 

--- a/R/tab_desc.R
+++ b/R/tab_desc.R
@@ -13,14 +13,14 @@
 #' @export
 
 tab_desc <- function(df, column){
-  aux <- df %>% select(tempos, censura, .y. = all_of(column))
+  data <- df %>% select(tempos, censura, .y. = all_of(column))
   
   # separate execution based on variable type
-  if(class(aux$.y.) %in% c('integer', 'numeric')){
+  if(class(data$.y.) %in% c('integer', 'numeric')){
     
     # numeric variable ----
     
-    aux <- tab_desc_num(aux, column) %>%
+    data <- tab_desc_num(data, column) %>%
       mutate(highlight = 'J2') %>% ungroup %>%
       # add dividing line to organize the table and highlight the
       # name of the variable being analysed
@@ -30,35 +30,35 @@ tab_desc <- function(df, column){
               # kableExtra::row_spec, for instance to mark numeric or
               # categorical variables with different colors
               highlight = 'J1',
-              ., .before = 1, group1 = msdr(aux$.y.))
+              ., .before = 1, frequency_col = msdr(data$.y.))
   }else{
     
     # categorical variable ----
     # show which categorical levels exist for the variable
 
-    exemplo_niveis <- paste('Levels:', paste(sort(unique(aux$.y.)),
+    exemplo_niveis <- paste('Levels:', paste(sort(unique(data$.y.)),
                                              collapse = ', '))
     # limit length of the string to avoid breaking the table layout
     if(nchar(exemplo_niveis) > 20){
       exemplo_niveis <- paste0(str_trim(str_sub(exemplo_niveis, end = 20)), '...')}
 
     try_error <- class(try(
-      survdiff(data = aux, Surv(aux$tempos, aux$censura)~.y.)[["pvalue"]],
+      survdiff(data = data, Surv(data$tempos, data$censura)~.y.)[["pvalue"]],
       silent = TRUE))
     if(try_error=='try-error'){
       p_value <- 1}else{
-        p_value <- survdiff(data = aux,Surv(aux$tempos, aux$censura)~.y.)[["pvalue"]]}
+        p_value <- survdiff(data = data,Surv(data$tempos, data$censura)~.y.)[["pvalue"]]}
     
     # add dividing line to organize the table
-    aux <- tab_desc_fac(aux) %>%
+    data <- tab_desc_fac(data) %>%
       mutate(highlight = 'J2') %>% ungroup %>%
       add_row(.y. = paste0('[', str_replace_all(stringr::str_to_title(column),
                                                 '_', ' '), ']'),
               ., .before = 1, highlight = 'J1',
-              group1 = exemplo_niveis,
+              frequency_col = exemplo_niveis,
               p = as.character(format_sig(p_value)),
               test = '(Logrank)')
   }
-  aux %>% add_row(.after = nrow(aux), highlight = '.')
+  data %>% add_row(.after = nrow(data), highlight = '.')
 }
 

--- a/R/tab_desc_fac.R
+++ b/R/tab_desc_fac.R
@@ -1,15 +1,15 @@
 #' Combine frequency and survival summaries for factors
 #'
 #' @description Helper for `tab_desc` used when the analysed variable is categorical.
-#' @param aux Data frame with columns `tempos`, `censura` and `.y.`.
+#' @param data Data frame with columns `tempos`, `censura` and `.y.`.
 #' @importFrom dplyr ungroup full_join join_by
 #' @return Tibble with counts and mean survival for each level.
 #' @examples
 #' tab_desc_fac(tibble::tibble(tempos=1:2, censura=c(1,0), .y.=c('A','B')))
 #' @export
  
-tab_desc_fac <- function(aux){
-  ungroup(full_join(tab_freq(aux), 
-                    msdr_y(aux), by = join_by(.y.)))
+tab_desc_fac <- function(data){
+  ungroup(full_join(tab_freq(data),
+                    msdr_y(data), by = join_by(.y.)))
 }
 

--- a/R/tab_desc_num.R
+++ b/R/tab_desc_num.R
@@ -1,7 +1,7 @@
 #' Cox model summary row
 #'
 #' @description Generate a descriptive row for a numeric covariate using Cox regression.
-#' @param aux Data frame with columns `tempos`, `censura` and the numeric variable `.y.`.
+#' @param data Data frame with columns `tempos`, `censura` and the numeric variable `.y.`.
 #' @param column Name of the numeric column.
 #' @param k Number of decimal places for rounding.
 #' @param test Label for the statistical test to display.
@@ -12,13 +12,13 @@
 #' tab_desc_num(lung %>% dplyr::select(tempos, censura, .y.=age), 'age')
 #' @export
 
-tab_desc_num <- function(aux, column, k = 4, test = '-'){
-  fit <- coxph(data = aux, Surv(aux$tempos, aux$censura)~.y.)
+tab_desc_num <- function(data, column, k = 4, test = '-'){
+  fit <- coxph(data = data, Surv(data$tempos, data$censura)~.y.)
   
   tibble(
     .y. = 'Regression coefficient',
-    group1 = NA,
-    group2 = fit %>% coef %>% exp %>% round(., k) %>% as.character, 
+    frequency_col = NA,
+    summary_text = fit %>% coef %>% exp %>% round(., k) %>% as.character,
     p = format_sig(summary(fit)[["sctest"]][["pvalue"]]),
     test = test
   )

--- a/R/tab_freq.R
+++ b/R/tab_freq.R
@@ -1,7 +1,7 @@
 #' Frequency table
 #'
 #' @description Create a simple frequency table for the column `.y.` of a data frame.
-#' @param aux Data frame containing a `.y.` column.
+#' @param data Data frame containing a `.y.` column.
 #' @importFrom dplyr select mutate group_by n distinct if_else arrange ungroup
 #' @importFrom stringr str_replace_all fixed
 #' @return Tibble with counts and percentages for each level.
@@ -9,20 +9,20 @@
 #' tab_freq(tibble::tibble(.y. = c('A','B','A')))
 #' @export
 
-tab_freq <- function(aux){
-  # aux <- df %>%
+tab_freq <- function(data){
+  # data <- df %>%
   #   select(tempos, censura, .y. = all_of(column))
-  aux %>% 
-    select(.y.) %>% 
+  data %>%
+    select(.y.) %>%
     mutate(n_total = n()) %>%
     group_by(.y.) %>%
     mutate(ni = n()) %>%
     distinct %>%
-    mutate(group1 = paste0(ni, ' (', round(ni/n_total*100, 2), '%)'),
-           group1 = str_replace_all(group1, pattern = fixed('.'),replacement = ','),
+    mutate(frequency_col = paste0(ni, ' (', round(ni/n_total*100, 2), '%)'),
+           frequency_col = str_replace_all(frequency_col, pattern = fixed('.'),replacement = ','),
            .y. = if_else(is.na(.y.), 'xNA', .y.),
            p = ' ',
-           test = ' ') %>% 
+           test = ' ') %>%
     select(-n_total, -ni) %>%
     arrange(.y.) %>% 
     ungroup

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ df <- survival::lung |>
 
 tab_desc(df, "age")
 #> # A tibble: 3 × 5
-#>   .y.                    group1 group2 p     test  
-#>   <chr>                  <chr>  <chr>  <chr> <chr> 
-#> 1 [Age]                  62.0   NA     NA    NA    
-#> 2 Regression coefficient NA     1.01   0.45  (Cox PH)
-#> 3 .                      NA     NA     NA    NA    
+#>   .y.                    frequency_col summary_text p     test
+#>   <chr>                  <chr>         <chr>        <chr> <chr>
+#> 1 [Age]                  62.0          NA           NA    NA
+#> 2 Regression coefficient NA            1.01         0.45  (Cox PH)
+#> 3 .                      NA            NA           NA    NA
 
 complete_tab(df)
 #> Renders a scrolling HTML table summarising all columns

--- a/tests/testthat/test-msdr_y.R
+++ b/tests/testthat/test-msdr_y.R
@@ -14,7 +14,7 @@ fit <- survival::survfit(survival::Surv(tempos, censura) ~ group, data = sample_
 fit_sum <- data.frame(summary(fit)$table)
 expected <- tibble::tibble(
   .y. = c('A','B'),
-  group2 = c(
+  summary_text = c(
     SurvInsights:::format_msdr(
       round(fit_sum$rmean[1], 2),
       round(fit_sum$se.rmean[1], 2),
@@ -33,5 +33,5 @@ expected <- tibble::tibble(
 
 test_that("msdr_y summarises groups correctly", {
   expect_equal(res$.y., expected$.y.)
-  expect_equal(res$group2, expected$group2)
+  expect_equal(res$summary_text, expected$summary_text)
 })

--- a/tests/testthat/test-tab_desc_num.R
+++ b/tests/testthat/test-tab_desc_num.R
@@ -11,8 +11,8 @@ res <- tab_desc_num(aux, 'age', test = 'Cox PH')
 fit <- survival::coxph(data = aux, survival::Surv(aux$tempos, aux$censura)~.y.)
 expected <- tibble::tibble(
   .y. = 'Regression coefficient',
-  group1 = NA,
-  group2 = as.character(round(exp(coef(fit)), 4)),
+  frequency_col = NA,
+  summary_text = as.character(round(exp(coef(fit)), 4)),
   p = format_sig(summary(fit)[["sctest"]][["pvalue"]]),
   test = 'Cox PH'
 )

--- a/tests/testthat/test-tab_freq.R
+++ b/tests/testthat/test-tab_freq.R
@@ -6,7 +6,7 @@ res <- tab_freq(test_df)
 
 expected <- tibble::tibble(
   .y. = c('A','B','xNA'),
-  group1 = c('2 (50%)','1 (25%)','1 (25%)'),
+  frequency_col = c('2 (50%)','1 (25%)','1 (25%)'),
   p = ' ',
   test = ' '
 )


### PR DESCRIPTION
## Summary
- rename aux input to data across R helpers
- clarify group1/group2 columns as frequency_col and summary_text
- adjust tests and README for new column names

## Testing
- `pytest` (no tests ran)
- `R -q -e "testthat::test_dir('tests/legacy')"` (failed: there is no package called 'testthat')

------
https://chatgpt.com/codex/tasks/task_e_689557565170832dba8f01161cf08b6f