### PR TITLE
Allow custom time and event columns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,5 +9,6 @@ Imports:
     stringr,
     tibble,
     kableExtra,
-    survival
+    survival,
+    rlang
 RoxygenNote: 7.3.2

--- a/R/complete_tab.R
+++ b/R/complete_tab.R
@@ -2,14 +2,17 @@
 #' @importFrom kableExtra kbl kable_classic row_spec column_spec scroll_box footnote
 NULL
 
-complete_tab <- function(data){
+complete_tab <- function(data, time_col = "tempos", event_col = "censura"){
 
   columns <- column_classifier(data) %>%
-    filter(!(column %in% c('tempos', 'censura', '.y.'))) %>%
+    filter(!(column %in% c(time_col, event_col, '.y.'))) %>%
     pull(column)
 
   table <- do.call(rbind,
-                   lapply(as.list(columns), FUN = function(x)tab_desc(data,x)))
+                   lapply(as.list(columns),
+                          FUN = function(x) tab_desc(data, x,
+                                                      time_col = time_col,
+                                                      event_col = event_col)))
   
   table %>%
     kbl('html', digits = 4, escape = FALSE, booktabs = TRUE,

--- a/R/msdr_y.R
+++ b/R/msdr_y.R
@@ -1,8 +1,10 @@
 #' Mean survival by group
 #'
 #' @description Compute mean survival time and standard error for each group in a dataset.
-#' @param data Data frame with columns `tempos`, `censura` and grouping variable `.y.`.
+#' @param data Data frame with time, event and grouping variable `.y.`.
 #' @param k Number of decimal places for rounding.
+#' @param time_col Name of the time-to-event column.
+#' @param event_col Name of the event indicator column.
 #' @importFrom tibble tibble
 #' @importFrom dplyr mutate across select
 #' @importFrom stringr str_remove
@@ -11,12 +13,14 @@
 #' @examples
 #' df <- tibble::tibble(tempos = c(1,2), censura = c(1,0), .y. = c('A','B'))
 #' msdr_y(df)
+#' df2 <- dplyr::rename(df, tempo = tempos, evento = censura)
+#' msdr_y(df2, time_col = "tempo", event_col = "evento")
 #' @export
-msdr_y <- function(data, k = 2){
+msdr_y <- function(data, k = 2, time_col = "tempos", event_col = "censura"){
 
   if(length(unique(data$.y.)) < 2){
     fit <- survfit(data = data,
-                   Surv(data$tempos, data$censura)~.y.)
+                   Surv(data[[time_col]], data[[event_col]])~.y.)
     fit_sum <- data.frame(t(summary(fit)$table))
     tibble(.y. = data$.y.[1],
            media = fit_sum$rmean,
@@ -28,7 +32,7 @@ msdr_y <- function(data, k = 2){
       select(.y., summary_text)
   }else{
     fit <- survfit(data = data,
-                   Surv(data$tempos, data$censura)~.y.)
+                   Surv(data[[time_col]], data[[event_col]])~.y.)
     fit_sum <- data.frame(summary(fit)$table)
 
     tibble(.y. = str_remove(rownames(fit_sum), '.y.='),

--- a/R/tab_desc.R
+++ b/R/tab_desc.R
@@ -1,8 +1,10 @@
 #' Descriptive statistics for one column
 #'
 #' @description Summarise a variable with counts and survival metrics.
-#' @param df Data frame containing `tempos`, `censura` and the variable.
+#' @param df Data frame containing time, event and the target variable.
 #' @param column Name of the column to be analysed.
+#' @param time_col Name of the time-to-event column.
+#' @param event_col Name of the event indicator column.
 #' @importFrom dplyr select mutate ungroup all_of
 #' @importFrom tibble add_row
 #' @importFrom stringr str_replace_all str_to_title str_trim str_sub
@@ -10,17 +12,21 @@
 #' @return A tibble with frequency and survival information formatted for tables.
 #' @examples
 #' tab_desc(lung, "sex")
+#' df2 <- dplyr::rename(lung, tempo = time, evento = status)
+#' tab_desc(df2, "sex", time_col = "tempo", event_col = "evento")
 #' @export
 
-tab_desc <- function(df, column){
-  data <- df %>% select(tempos, censura, .y. = all_of(column))
+tab_desc <- function(df, column, time_col = "tempos", event_col = "censura"){
+  time_col_sym <- rlang::sym(time_col)
+  event_col_sym <- rlang::sym(event_col)
+  data <- df %>% select({{time_col_sym}}, {{event_col_sym}}, .y. = all_of(column))
   
   # separate execution based on variable type
   if(class(data$.y.) %in% c('integer', 'numeric')){
     
     # numeric variable ----
     
-    data <- tab_desc_num(data, column) %>%
+    data <- tab_desc_num(data, column, time_col = time_col, event_col = event_col) %>%
       mutate(highlight = 'J2') %>% ungroup %>%
       # add dividing line to organize the table and highlight the
       # name of the variable being analysed
@@ -43,14 +49,16 @@ tab_desc <- function(df, column){
       exemplo_niveis <- paste0(str_trim(str_sub(exemplo_niveis, end = 20)), '...')}
 
     try_error <- class(try(
-      survdiff(data = data, Surv(data$tempos, data$censura)~.y.)[["pvalue"]],
+      survdiff(data = data,
+               Surv(data[[time_col]], data[[event_col]])~.y.)[["pvalue"]],
       silent = TRUE))
     if(try_error=='try-error'){
       p_value <- 1}else{
-        p_value <- survdiff(data = data,Surv(data$tempos, data$censura)~.y.)[["pvalue"]]}
+        p_value <- survdiff(data = data,
+                            Surv(data[[time_col]], data[[event_col]])~.y.)[["pvalue"]]}
     
     # add dividing line to organize the table
-    data <- tab_desc_fac(data) %>%
+    data <- tab_desc_fac(data, time_col = time_col, event_col = event_col) %>%
       mutate(highlight = 'J2') %>% ungroup %>%
       add_row(.y. = paste0('[', str_replace_all(stringr::str_to_title(column),
                                                 '_', ' '), ']'),

--- a/R/tab_desc_fac.R
+++ b/R/tab_desc_fac.R
@@ -1,15 +1,20 @@
 #' Combine frequency and survival summaries for factors
 #'
 #' @description Helper for `tab_desc` used when the analysed variable is categorical.
-#' @param data Data frame with columns `tempos`, `censura` and `.y.`.
+#' @param data Data frame with time, event and `.y.`.
+#' @param time_col Name of the time-to-event column.
+#' @param event_col Name of the event indicator column.
 #' @importFrom dplyr ungroup full_join join_by
 #' @return Tibble with counts and mean survival for each level.
 #' @examples
 #' tab_desc_fac(tibble::tibble(tempos=1:2, censura=c(1,0), .y.=c('A','B')))
+#' df2 <- tibble::tibble(tempo=1:2, evento=c(1,0), .y.=c('A','B'))
+#' tab_desc_fac(df2, time_col = "tempo", event_col = "evento")
 #' @export
  
-tab_desc_fac <- function(data){
+tab_desc_fac <- function(data, time_col = "tempos", event_col = "censura"){
   ungroup(full_join(tab_freq(data),
-                    msdr_y(data), by = join_by(.y.)))
+                    msdr_y(data, time_col = time_col, event_col = event_col),
+                    by = join_by(.y.)))
 }
 

--- a/R/tab_desc_num.R
+++ b/R/tab_desc_num.R
@@ -1,19 +1,24 @@
 #' Cox model summary row
 #'
 #' @description Generate a descriptive row for a numeric covariate using Cox regression.
-#' @param data Data frame with columns `tempos`, `censura` and the numeric variable `.y.`.
+#' @param data Data frame with time, event and the numeric variable `.y.`.
 #' @param column Name of the numeric column.
 #' @param k Number of decimal places for rounding.
 #' @param test Label for the statistical test to display.
+#' @param time_col Name of the time-to-event column.
+#' @param event_col Name of the event indicator column.
 #' @importFrom survival coxph Surv
 #' @importFrom tibble tibble
 #' @return A tibble with the regression coefficient and p-value.
 #' @examples
 #' tab_desc_num(lung %>% dplyr::select(tempos, censura, .y.=age), 'age')
+#' df2 <- lung %>% dplyr::select(t = time, e = status, .y. = age)
+#' tab_desc_num(df2, 'age', time_col = 't', event_col = 'e')
 #' @export
 
-tab_desc_num <- function(data, column, k = 4, test = '-'){
-  fit <- coxph(data = data, Surv(data$tempos, data$censura)~.y.)
+tab_desc_num <- function(data, column, k = 4, test = '-',
+                         time_col = "tempos", event_col = "censura"){
+  fit <- coxph(data = data, Surv(data[[time_col]], data[[event_col]])~.y.)
   
   tibble(
     .y. = 'Regression coefficient',

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ library(SurvInsights)
 library(survival)
 library(dplyr)
 
-df <- survival::lung |> 
+df <- survival::lung |>
   select(tempos = time, censura = status, age, sex)
 
+# default column names
 tab_desc(df, "age")
 #> # A tibble: 3 × 5
 #>   .y.                    frequency_col summary_text p     test
@@ -35,6 +36,10 @@ tab_desc(df, "age")
 
 complete_tab(df)
 #> Renders a scrolling HTML table summarising all columns
+
+# using alternative column names
+df_alt <- survival::lung |> select(tempo = time, evento = status, age, sex)
+tab_desc(df_alt, "age", time_col = "tempo", event_col = "evento")
 ```
 
 ## Sample datasets

--- a/man/msdr_y.Rd
+++ b/man/msdr_y.Rd
@@ -4,12 +4,16 @@
 \alias{msdr_y}
 \title{Mean survival by group}
 \usage{
-msdr_y(aux, k = 2)
+msdr_y(data, k = 2, time_col = "tempos", event_col = "censura")
 }
 \arguments{
-\item{aux}{Data frame with columns `tempos`, `censura` and grouping variable `.y.`.}
+\item{data}{Data frame with time, event and grouping variable `.y.`.}
 
 \item{k}{Number of decimal places for rounding.}
+
+\item{time_col}{Name of the time-to-event column.}
+
+\item{event_col}{Name of the event indicator column.}
 }
 \value{
 A tibble with group labels and a formatted summary string.
@@ -20,4 +24,6 @@ Compute mean survival time and standard error for each group in a dataset.
 \examples{
 df <- tibble::tibble(tempos = c(1,2), censura = c(1,0), .y. = c('A','B'))
 msdr_y(df)
+df2 <- dplyr::rename(df, tempo = tempos, evento = censura)
+msdr_y(df2, time_col = "tempo", event_col = "evento")
 }

--- a/man/tab_desc.Rd
+++ b/man/tab_desc.Rd
@@ -4,12 +4,16 @@
 \alias{tab_desc}
 \title{Descriptive statistics for one column}
 \usage{
-tab_desc(df, column)
+tab_desc(df, column, time_col = "tempos", event_col = "censura")
 }
 \arguments{
-\item{df}{Data frame containing `tempos`, `censura` and the variable.}
+\item{df}{Data frame containing time, event and the variable.}
 
 \item{column}{Name of the column to be analysed.}
+
+\item{time_col}{Name of the time-to-event column.}
+
+\item{event_col}{Name of the event indicator column.}
 }
 \value{
 A tibble with frequency and survival information formatted for tables.
@@ -19,4 +23,6 @@ Summarise a variable with counts and survival metrics.
 }
 \examples{
 tab_desc(lung, "sex")
+df2 <- dplyr::rename(lung, tempo = time, evento = status)
+tab_desc(df2, "sex", time_col = "tempo", event_col = "evento")
 }

--- a/man/tab_desc_fac.Rd
+++ b/man/tab_desc_fac.Rd
@@ -4,10 +4,14 @@
 \alias{tab_desc_fac}
 \title{Combine frequency and survival summaries for factors}
 \usage{
-tab_desc_fac(aux)
+tab_desc_fac(data, time_col = "tempos", event_col = "censura")
 }
 \arguments{
-\item{aux}{Data frame with columns `tempos`, `censura` and `.y.`.}
+\item{data}{Data frame with time, event and `.y.`.}
+
+\item{time_col}{Name of the time-to-event column.}
+
+\item{event_col}{Name of the event indicator column.}
 }
 \value{
 Tibble with counts and mean survival for each level.
@@ -17,4 +21,6 @@ Helper for `tab_desc` used when the analysed variable is categorical.
 }
 \examples{
 tab_desc_fac(tibble::tibble(tempos=1:2, censura=c(1,0), .y.=c('A','B')))
+df2 <- tibble::tibble(tempo=1:2, evento=c(1,0), .y.=c('A','B'))
+tab_desc_fac(df2, time_col = "tempo", event_col = "evento")
 }

--- a/man/tab_desc_num.Rd
+++ b/man/tab_desc_num.Rd
@@ -4,16 +4,21 @@
 \alias{tab_desc_num}
 \title{Cox model summary row}
 \usage{
-tab_desc_num(aux, column, k = 4, test = "-")
+tab_desc_num(data, column, k = 4, test = "-",
+  time_col = "tempos", event_col = "censura")
 }
 \arguments{
-\item{aux}{Data frame with columns `tempos`, `censura` and the numeric variable `.y.`.}
+\item{data}{Data frame with time, event and the numeric variable `.y.`.}
 
 \item{column}{Name of the numeric column.}
 
 \item{k}{Number of decimal places for rounding.}
 
 \item{test}{Label for the statistical test to display.}
+
+\item{time_col}{Name of the time-to-event column.}
+
+\item{event_col}{Name of the event indicator column.}
 }
 \value{
 A tibble with the regression coefficient and p-value.
@@ -23,4 +28,6 @@ Generate a descriptive row for a numeric covariate using Cox regression.
 }
 \examples{
 tab_desc_num(lung \%>\% dplyr::select(tempos, censura, .y.=age), 'age')
+df2 <- lung \%>\% dplyr::select(t = time, e = status, .y. = age)
+tab_desc_num(df2, 'age', time_col = 't', event_col = 'e')
 }

--- a/tests/testthat/test-complete_tab.R
+++ b/tests/testthat/test-complete_tab.R
@@ -6,9 +6,14 @@ test_that('complete_tab returns knitr_kable with expected columns', {
     censura = c(1, 0),
     age = c(60, 70)
   )
+  df2 <- dplyr::rename(df, tempo = tempos, evento = censura)
 
   res <- complete_tab(df)
+  res2 <- complete_tab(df2, time_col = 'tempo', event_col = 'evento')
   expect_s3_class(res, 'knitr_kable')
+  expect_s3_class(res2, 'knitr_kable')
   expect_equal(attr(res, 'kable_meta')$col_names,
+               c('.y.', 'group1', 'group2', 'p', 'test', 'highlight'))
+  expect_equal(attr(res2, 'kable_meta')$col_names,
                c('.y.', 'group1', 'group2', 'p', 'test', 'highlight'))
 })

--- a/tests/testthat/test-msdr_y.R
+++ b/tests/testthat/test-msdr_y.R
@@ -8,7 +8,11 @@ sample_df <- tibble::tibble(
   group = c('A', 'B', 'A', 'B', 'A', 'B')
 )
 
+sample_df2 <- sample_df %>% dplyr::rename(tempo = tempos, evento = censura)
+
 res <- msdr_y(sample_df %>% dplyr::select(tempos, censura, .y. = group), k = 2)
+res2 <- msdr_y(sample_df2 %>% dplyr::select(tempo, evento, .y. = group),
+               k = 2, time_col = 'tempo', event_col = 'evento')
 
 fit <- survival::survfit(survival::Surv(tempos, censura) ~ group, data = sample_df)
 fit_sum <- data.frame(summary(fit)$table)
@@ -34,4 +38,9 @@ expected <- tibble::tibble(
 test_that("msdr_y summarises groups correctly", {
   expect_equal(res$.y., expected$.y.)
   expect_equal(res$summary_text, expected$summary_text)
+})
+
+test_that("msdr_y accepts custom column names", {
+  expect_equal(res2$.y., expected$.y.)
+  expect_equal(res2$summary_text, expected$summary_text)
 })

--- a/tests/testthat/test-tab_desc.R
+++ b/tests/testthat/test-tab_desc.R
@@ -7,8 +7,12 @@ test_df <- tibble::tibble(
   group = c('A','B','A','B','A','B')
 )
 
+renamed_df <- test_df %>% dplyr::rename(tempo = tempos, evento = censura)
+
 num_res <- tab_desc(test_df, 'age')
 cat_res <- tab_desc(test_df, 'group')
+num_res_alt <- tab_desc(renamed_df, 'age', time_col = 'tempo', event_col = 'evento')
+cat_res_alt <- tab_desc(renamed_df, 'group', time_col = 'tempo', event_col = 'evento')
 
 
 test_that('tab_desc works for numeric variables', {
@@ -20,4 +24,9 @@ test_that('tab_desc works for numeric variables', {
 test_that('tab_desc works for categorical variables', {
   expect_true('[Group]' %in% cat_res$.y.)
   expect_true(all(sort(unique(test_df$group)) %in% cat_res$.y.))
+})
+
+test_that('tab_desc supports custom time/event columns', {
+  expect_true('[Age]' %in% num_res_alt$.y.)
+  expect_true(all(sort(unique(renamed_df$group)) %in% cat_res_alt$.y.))
 })

--- a/tests/testthat/test-tab_desc_fac.R
+++ b/tests/testthat/test-tab_desc_fac.R
@@ -6,10 +6,20 @@ sample_df <- tibble::tibble(
   group = c('A','B','A','B','A','B')
 )
 aux <- sample_df %>% dplyr::select(tempos, censura, .y.=group)
+sample_df2 <- sample_df %>% dplyr::rename(tempo = tempos, evento = censura)
+aux2 <- sample_df2 %>% dplyr::select(tempo, evento, .y.=group)
 
 res <- tab_desc_fac(aux)
 expected <- dplyr::ungroup(dplyr::full_join(tab_freq(aux), msdr_y(aux), by = dplyr::join_by(.y.)))
+res2 <- tab_desc_fac(aux2, time_col = 'tempo', event_col = 'evento')
+expected2 <- dplyr::ungroup(dplyr::full_join(tab_freq(aux2),
+                                             msdr_y(aux2, time_col = 'tempo', event_col = 'evento'),
+                                             by = dplyr::join_by(.y.)))
 
 test_that("tab_desc_fac combines freq and msdr_y", {
   expect_equal(res, expected)
+})
+
+test_that("tab_desc_fac handles custom columns", {
+  expect_equal(res2, expected2)
 })

--- a/tests/testthat/test-tab_desc_num.R
+++ b/tests/testthat/test-tab_desc_num.R
@@ -6,6 +6,8 @@ sample_df <- tibble::tibble(
   age = c(70,45,63,50,80,58)
 )
 aux <- sample_df %>% dplyr::select(tempos, censura, .y.=age)
+sample_df2 <- sample_df %>% dplyr::rename(tempo = tempos, evento = censura)
+aux2 <- sample_df2 %>% dplyr::select(tempo, evento, .y.=age)
 
 res <- tab_desc_num(aux, 'age', test = 'Cox PH')
 fit <- survival::coxph(data = aux, survival::Surv(aux$tempos, aux$censura)~.y.)
@@ -17,6 +19,20 @@ expected <- tibble::tibble(
   test = 'Cox PH'
 )
 
+res2 <- tab_desc_num(aux2, 'age', test = 'Cox PH', time_col = 'tempo', event_col = 'evento')
+fit2 <- survival::coxph(data = aux2, survival::Surv(aux2$tempo, aux2$evento)~.y.)
+expected2 <- tibble::tibble(
+  .y. = 'Regression coefficient',
+  frequency_col = NA,
+  summary_text = as.character(round(exp(coef(fit2)), 4)),
+  p = format_sig(summary(fit2)[["sctest"]][["pvalue"]]),
+  test = 'Cox PH'
+)
+
 test_that("tab_desc_num fits cox model", {
   expect_equal(res, expected)
+})
+
+test_that("tab_desc_num handles custom columns", {
+  expect_equal(res2, expected2)
 })


### PR DESCRIPTION
## Summary
- Make time and event columns configurable across descriptive helpers
- Update documentation, README examples and tests for custom column names
- Add `rlang` import for new tidy-eval usage

## Testing
- `pytest`
- `R -q -e "testthat::test_dir('tests/legacy')"` *(fails: No test files found)*
- `R -q -e "testthat::test_dir('tests/testthat')"` *(fails: package 'SurvInsights' not installed due to missing system libraries)*

------
https://chatgpt.com/codex/tasks/task_e_68955e3c29ac832d9545baa22515746c